### PR TITLE
endrer fra navn til time zone offset pga thin mode changes mars 2023

### DIFF
--- a/models/dvh_syfo/forkammer/modia/fk_modia__aktivitetskrav.sql
+++ b/models/dvh_syfo/forkammer/modia/fk_modia__aktivitetskrav.sql
@@ -14,8 +14,8 @@ WITH aktivitetskrav AS (
   SELECT
       JSON_VALUE(aktivitetskrav.KAFKA_MESSAGE, '$.uuid') AS kilde_uuid,
       JSON_VALUE(aktivitetskrav.KAFKA_MESSAGE, '$.personIdent') AS personIdent,
-      TO_TIMESTAMP_TZ(JSON_VALUE(aktivitetskrav.KAFKA_MESSAGE, '$.stoppunktAt'), 'YYYY-MM-DD HH24:MI:SS.FF:TZH:TZM') AT TIME ZONE 'CET' AS stoppunktAt,
-       TO_TIMESTAMP_TZ(JSON_VALUE(aktivitetskrav.KAFKA_MESSAGE,'$.createdAt'), 'yyyy-mm-dd"T"hh24:mi:ss.fftzh:tzm"Z"') AT TIME ZONE 'CET' as createdAt,
+      TO_TIMESTAMP_TZ(JSON_VALUE(aktivitetskrav.KAFKA_MESSAGE, '$.stoppunktAt'), 'YYYY-MM-DD HH24:MI:SS.FF:TZH:TZM') AT TIME ZONE '+01:00' AS stoppunktAt,
+       TO_TIMESTAMP_TZ(JSON_VALUE(aktivitetskrav.KAFKA_MESSAGE,'$.createdAt'), 'yyyy-mm-dd"T"hh24:mi:ss.fftzh:tzm"Z"') AT TIME ZONE '+01:00' as createdAt,
         JSON_VALUE(aktivitetskrav.KAFKA_MESSAGE, '$.status') as status,
         --JSON_TABLE(aktivitetskrav.KAFKA_MESSAGE, '$.arsaker[*]'
         -- COLUMNS (arsaker VARCHAR2(100) PATH '$')) AS arsaker,
@@ -23,7 +23,7 @@ WITH aktivitetskrav AS (
         JSON_VALUE(aktivitetskrav.KAFKA_MESSAGE, '$.arsaker[1]') AS arsaker1,
         JSON_VALUE(aktivitetskrav.KAFKA_MESSAGE, '$.arsaker[2]') AS arsaker2,
         json_value(aktivitetskrav.kafka_message,'$.updatedBy') as updatedBy,
-        TO_TIMESTAMP_TZ(JSON_VALUE(aktivitetskrav.kafka_message,'$.sistVurdert'), 'yyyy-mm-dd"T"hh24:mi:ss.fftzh:tzm"Z"') AT TIME ZONE 'CET' AS sistVurdert,
+        TO_TIMESTAMP_TZ(JSON_VALUE(aktivitetskrav.kafka_message,'$.sistVurdert'), 'yyyy-mm-dd"T"hh24:mi:ss.fftzh:tzm"Z"') AT TIME ZONE '+01:00' AS sistVurdert,
     kafka_topic,
     kafka_partisjon,
     kafka_offset,

--- a/models/dvh_syfo/forkammer/modia/fk_modia__dialogmote.sql
+++ b/models/dvh_syfo/forkammer/modia/fk_modia__dialogmote.sql
@@ -5,14 +5,14 @@ WITH dialogmote AS (
 , final AS (
   SELECT
     dialogmote.kafka_message.dialogmoteUuid as kilde_uuid,
-    TO_TIMESTAMP_TZ(dialogmote.kafka_message.dialogmoteTidspunkt, 'YYYY-MM-DD HH24:MI:SS:TZH:TZM') AT TIME ZONE 'CET' AS dialogmote_tidspunkt,
+    TO_TIMESTAMP_TZ(dialogmote.kafka_message.dialogmoteTidspunkt, 'YYYY-MM-DD HH24:MI:SS:TZH:TZM') AT TIME ZONE '+01:00' AS dialogmote_tidspunkt,
     dialogmote.kafka_message.statusEndringType as hendelse,
-    TO_TIMESTAMP_TZ(dialogmote.kafka_message.statusEndringTidspunkt, 'YYYY-MM-DD HH24:MI:SS.FF:TZH:TZM') AT TIME ZONE 'CET' AS hendelse_tidspunkt,
+    TO_TIMESTAMP_TZ(dialogmote.kafka_message.statusEndringTidspunkt, 'YYYY-MM-DD HH24:MI:SS.FF:TZH:TZM') AT TIME ZONE '+01:00' AS hendelse_tidspunkt,
     dialogmote.kafka_message.personIdent as person_ident,
     dialogmote.kafka_message.virksomhetsnummer as virksomhetsnr,
     dialogmote.kafka_message.enhetNr as enhet_nr,
     dialogmote.kafka_message.navIdent as nav_ident,
-    TO_TIMESTAMP_TZ(dialogmote.kafka_message.tilfelleStartdato, 'YYYY-MM-DD HH24:MI:SS:TZH:TZM') AT TIME ZONE 'CET' AS tilfelle_startdato,
+    TO_TIMESTAMP_TZ(dialogmote.kafka_message.tilfelleStartdato, 'YYYY-MM-DD HH24:MI:SS:TZH:TZM') AT TIME ZONE '+01:00' AS tilfelle_startdato,
     DECODE(dialogmote.kafka_message.arbeidstaker, 'true', 1, 'false', 0) AS arbeidstaker_flagg,
     DECODE(dialogmote.kafka_message.arbeidsgiver, 'true', 1, 'false', 0) AS arbeidsgiver_flagg,
     DECODE(dialogmote.kafka_message.sykmelder, 'true', 1, 'false', 0) AS sykmelder_flagg,

--- a/models/dvh_syfo/forkammer/modia/fk_modia__dialogmote_patch.sql
+++ b/models/dvh_syfo/forkammer/modia/fk_modia__dialogmote_patch.sql
@@ -6,21 +6,21 @@ with dialogmote_forkammer as
 , dialogmote_patch as (
   select dialogmote_forkammer.*,
   case
-  when kilde_uuid = '92097f17-1e02-4449-8eaf-d5a50d05220e' and hendelse in ('FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-06-01','YYYY-MM-DD') at TIME ZONE 'CET' /*hentet fra annen modia hendelse*/
-  when kilde_uuid = 'c7745c33-fdff-42f8-a6dc-5d3dc4aed983' and hendelse in ('INNKALT','NYTT_TID_STED','FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-01-06','YYYY-MM-DD') at TIME ZONE 'CET' /*hentet fra arena hendelse*/
-  when kilde_uuid = 'b31aef9f-afaa-4d8e-9f31-d9d7d1bb3819' and hendelse in ('FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-08-28','YYYY-MM-DD') at TIME ZONE 'CET' /*hentet fra annen modia hendelse*/
-  when kilde_uuid = '57c2abe2-062d-45bd-b51d-898e063cd13b' and hendelse in ('FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-09-08', 'YYYY-MM-DD') at TIME ZONE 'CET' /*hentet fra annen modia hendelse*/
-  when kilde_uuid = '5b3881ac-e5da-4d57-a4e5-5eeb90bf645a' and hendelse in ('INNKALT', 'FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-03-20','YYYY-MM-DD') at TIME ZONE 'CET' /*hentet fra annen modia hendelse*/
-  when kilde_uuid = '159d7f6e-4ecf-487d-bf9e-1c9a8fb89e0d' and hendelse in ('FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-02-21','YYYY-MM-DD') at TIME ZONE 'CET' /*hentet fra annen modia hendelse*/
-  when kilde_uuid = '9358c264-6871-4bad-b62b-a3245b52530e' and hendelse in ('INNKALT','NYTT_TID_STED','FERDIGSTILT') then TO_TIMESTAMP_TZ('2021-12-17','YYYY-MM-DD') at TIME ZONE 'CET' /*hentet fra annen modia hendelse*/
-  when kilde_uuid = '4dfdc657-5879-40fc-a096-75d7562298c2' and hendelse in ('FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-08-18','YYYY-MM-DD') at TIME ZONE 'CET' /*hentet fra annen modia hendelse*/
-  when kilde_uuid = 'a2e8cd59-9eb4-44c7-bf4a-feb1da44312f' and hendelse in ('FERDIGSTILT', 'INNKALT') then TO_TIMESTAMP_TZ('2022-01-29','YYYY-MM-DD') at TIME ZONE 'CET' /*hentet fra arena oppfolging*/
-  when kilde_uuid = 'd6ed14e0-a98f-44fb-a114-88448b372b16' and hendelse in ('INNKALT','NYTT_TID_STED','FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-09-12','YYYY-MM-DD') at TIME ZONE 'CET' /*hentet fra arena oppfolging*/
-  when kilde_UUid = '812a477c-2543-427f-8cdb-fbef59f36123' and hendelse in ('FERDIGSTILT','INNKALT') then TO_TIMESTAMP_TZ('2022-02-28','YYYY-MM-DD') at TIME ZONE 'CET' /*hentet fra arena/infotrygd*/
-  when kilde_uuid = '3b5e4b16-3576-49c4-ba44-2393848e3fc5' and hendelse in ('INNKALT','NYTT_TID_STED','FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-08-12','YYYY-MM-DD') at TIME ZONE 'CET' /*hentet fra infotrygd/arena, fant ikke noe i sykm*/
-  when kilde_uuid = '1662ee9f-5186-4c5b-a43b-bd0c926d8d19' and hendelse in ('FERDIGSTILT') then to_timestamp_tz('2022-09-14','YYYY-MM-DD') at TIME ZONE 'CET' /*hentet fra annen dialogmote hendelse*/
-  when kilde_uuid = '7352a6f3-d7e2-4676-a2fe-de0c55f59f68' and hendelse in ('FERDIGSTILT','INNKALT') then  to_timestamp_tz('2023-01-23','YYYY-MM-DD') at TIME ZONE 'CET' /*hentet fra sf_oppfolging*/
-  when kilde_uuid = '7574b760-cef4-44a7-9c21-463055fd6a36' and hendelse in ('FERDIGSTILT','INNKALT') then  to_timestamp_tz('2023-10-09','YYYY-MM-DD') at TIME ZONE 'CET' /*hentet fra sf_oppfolging og sykm_sykmelding*/
+  when kilde_uuid = '92097f17-1e02-4449-8eaf-d5a50d05220e' and hendelse in ('FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-06-01','YYYY-MM-DD') AT TIME ZONE '+01:00' /*hentet fra annen modia hendelse*/
+  when kilde_uuid = 'c7745c33-fdff-42f8-a6dc-5d3dc4aed983' and hendelse in ('INNKALT','NYTT_TID_STED','FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-01-06','YYYY-MM-DD') AT TIME ZONE '+01:00' /*hentet fra arena hendelse*/
+  when kilde_uuid = 'b31aef9f-afaa-4d8e-9f31-d9d7d1bb3819' and hendelse in ('FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-08-28','YYYY-MM-DD') AT TIME ZONE '+01:00' /*hentet fra annen modia hendelse*/
+  when kilde_uuid = '57c2abe2-062d-45bd-b51d-898e063cd13b' and hendelse in ('FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-09-08', 'YYYY-MM-DD') AT TIME ZONE '+01:00' /*hentet fra annen modia hendelse*/
+  when kilde_uuid = '5b3881ac-e5da-4d57-a4e5-5eeb90bf645a' and hendelse in ('INNKALT', 'FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-03-20','YYYY-MM-DD') AT TIME ZONE '+01:00' /*hentet fra annen modia hendelse*/
+  when kilde_uuid = '159d7f6e-4ecf-487d-bf9e-1c9a8fb89e0d' and hendelse in ('FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-02-21','YYYY-MM-DD') AT TIME ZONE '+01:00' /*hentet fra annen modia hendelse*/
+  when kilde_uuid = '9358c264-6871-4bad-b62b-a3245b52530e' and hendelse in ('INNKALT','NYTT_TID_STED','FERDIGSTILT') then TO_TIMESTAMP_TZ('2021-12-17','YYYY-MM-DD') AT TIME ZONE '+01:00' /*hentet fra annen modia hendelse*/
+  when kilde_uuid = '4dfdc657-5879-40fc-a096-75d7562298c2' and hendelse in ('FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-08-18','YYYY-MM-DD') AT TIME ZONE '+01:00' /*hentet fra annen modia hendelse*/
+  when kilde_uuid = 'a2e8cd59-9eb4-44c7-bf4a-feb1da44312f' and hendelse in ('FERDIGSTILT', 'INNKALT') then TO_TIMESTAMP_TZ('2022-01-29','YYYY-MM-DD') AT TIME ZONE '+01:00' /*hentet fra arena oppfolging*/
+  when kilde_uuid = 'd6ed14e0-a98f-44fb-a114-88448b372b16' and hendelse in ('INNKALT','NYTT_TID_STED','FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-09-12','YYYY-MM-DD') AT TIME ZONE '+01:00' /*hentet fra arena oppfolging*/
+  when kilde_UUid = '812a477c-2543-427f-8cdb-fbef59f36123' and hendelse in ('FERDIGSTILT','INNKALT') then TO_TIMESTAMP_TZ('2022-02-28','YYYY-MM-DD') AT TIME ZONE '+01:00' /*hentet fra arena/infotrygd*/
+  when kilde_uuid = '3b5e4b16-3576-49c4-ba44-2393848e3fc5' and hendelse in ('INNKALT','NYTT_TID_STED','FERDIGSTILT') then TO_TIMESTAMP_TZ('2022-08-12','YYYY-MM-DD') AT TIME ZONE '+01:00' /*hentet fra infotrygd/arena, fant ikke noe i sykm*/
+  when kilde_uuid = '1662ee9f-5186-4c5b-a43b-bd0c926d8d19' and hendelse in ('FERDIGSTILT') then to_timestamp_tz('2022-09-14','YYYY-MM-DD') AT TIME ZONE '+01:00' /*hentet fra annen dialogmote hendelse*/
+  when kilde_uuid = '7352a6f3-d7e2-4676-a2fe-de0c55f59f68' and hendelse in ('FERDIGSTILT','INNKALT') then  to_timestamp_tz('2023-01-23','YYYY-MM-DD') AT TIME ZONE '+01:00' /*hentet fra sf_oppfolging*/
+  when kilde_uuid = '7574b760-cef4-44a7-9c21-463055fd6a36' and hendelse in ('FERDIGSTILT','INNKALT') then  to_timestamp_tz('2023-10-09','YYYY-MM-DD') AT TIME ZONE '+01:00' /*hentet fra sf_oppfolging og sykm_sykmelding*/
   else tilfelle_startdato
   end
   tilfelle_startdato_patch

--- a/models/dvh_syfo/forkammer/modia/fk_modia__kandidat.sql
+++ b/models/dvh_syfo/forkammer/modia/fk_modia__kandidat.sql
@@ -4,7 +4,7 @@ WITH kandidater AS (
 , final AS (
   SELECT
     kandidater.kafka_message.uuid as kilde_uuid,
-    TO_TIMESTAMP(kandidater.kafka_message.createdAt, 'yyyy-mm-dd"T"hh24:mi:ss.fftzh:tzm') AT TIME ZONE 'CET' AS hendelse_tidspunkt,
+    TO_TIMESTAMP(kandidater.kafka_message.createdAt, 'yyyy-mm-dd"T"hh24:mi:ss.fftzh:tzm') AT TIME ZONE '+01:00' AS hendelse_tidspunkt,
     kandidater.kafka_message.personIdentNumber as person_ident,
     DECODE(kandidater.kafka_message.kandidat, 'true', 1, 'false', 0) AS kandidat_flagg,
     kandidater.kafka_message.arsak as hendelse,


### PR DESCRIPTION
Etter å ha tatt i bruk dbt Power User-extension i VSCode, fikk jeg klager ved kjøring på `DPY-3022: named time zones are not supported in thin mode`. Googlet og fant release notes fra mars 2023 på thin mode [her](https://python-oracledb.readthedocs.io/en/latest/release_notes.html), som sier at å referere til navn på time zones ikke støttes lenger. Testet ved å bytte fra 'CET' til '+01:00', og det fungerte. Har nå lagt inn endringen alle steder slik at Power User fungerer. 