### PR TITLE
sto-3611 fix: null-håndtering og kommentarer

### DIFF
--- a/models/dvh_syfo/torg/fak_dialogmote.sql
+++ b/models/dvh_syfo/torg/fak_dialogmote.sql
@@ -22,56 +22,134 @@ WITH hendelser AS (
 
 ,motebehov AS (
   SELECT * FROM {{ ref('mk_motebehov__prepp') }}
-)
-,dm_2_7 as (
--- copilot er benyttet til å analysere og utvide spørring med flere dialogmøter basert på eksisterende kode
+),
+
+dm_2 as (
 /*
-Sjekker for hver dialogmotetidspunkt 1 til 7
-1. Hvis dialogmote_tidspunkt = NULL,                             => NULL
-2. Hvis dialogmote_tidspunkt > unntaksdato,                      => NULL
-3. Hvis (dialogmote_tidspunkt - tilfelle_startdato) > 365 dager, => NULL
-4. Hvis unntaksdato = NULL,                                      => dialogmote_tidspunkt
-5. Hvis dialogmøtetidspunkt < unntaksdato,                       => dialogmote_tidspunkt
-6. Hvis dialogmøtetidspunkt > unntaksdato,                       => NULL eller tidspunkt for forrige dialogmøte
+Setter dialogmote2_avholdt_dato basert på reglene:
+1. Hvis dialogmote_tidspunkt1 = NULL,                             => NULL
+2. Hvis dialogmote_tidspunkt1 > unntak,                           => NULL (det er bare å få unntak kun for dialogmøte 2)
+3. Hvis (dialogmote_tidspunkt1 - tilfelle_startdato) > 365 dager, => NULL
+4. Hvis unntak = NULL,                                            => dialogmote_tidspunkt1
+5. Hvis dialogmote_tidspunkt1 < unntak,                           => dialogmote_tidspunkt1
 */
-  select fk_person1, tilfelle_startdato,
+  select fk_person1,
+         tilfelle_startdato,
+         dialogmote_tidspunkt1,
+         dialogmote_tidspunkt2,
+         dialogmote_tidspunkt3,
+         dialogmote_tidspunkt4,
+         dialogmote_tidspunkt5,
+         dialogmote_tidspunkt6,
     CASE
-      WHEN (dialogmote_tidspunkt1 is null) or (dialogmote_tidspunkt1 > unntak) or (extract(day from (dialogmote_tidspunkt1 - tilfelle_startdato))) > 365 then null
+      WHEN (dialogmote_tidspunkt1 is null) or (dialogmote_tidspunkt1 > unntak)
+                                           or (extract(day from (dialogmote_tidspunkt1 - tilfelle_startdato))) > 365 then null
       WHEN unntak is null then dialogmote_tidspunkt1
       WHEN dialogmote_tidspunkt1 < unntak then dialogmote_tidspunkt1
-    END AS dialogmote2_avholdt_dato,
+    END AS dialogmote2_avholdt_dato
+  from dvh_syfo.mk_dialogmote__pivotert
+  ),
+
+dm_3 as (
+/*
+Setter dialogmote3_avholdt_dato basert på reglene:
+1. Hvis dialogmote_tidspunkt2 = NULL,                             => NULL
+2. Hvis (dialogmote_tidspunkt2 - tilfelle_startdato) > 365 dager, => NULL
+3. Hvis dialogmote2_avholdt_dato = NULL,                          => dialogmote_tidspunkt1
+4. Ellers,                                                        => dialogmote_tidspunkt2
+*/
+  select dm_2.*,
     CASE
-      WHEN (dialogmote_tidspunkt2 is null) or extract(day from (dialogmote_tidspunkt2 - tilfelle_startdato)) > 365 then null
-      WHEN unntak is null then dialogmote_tidspunkt2
-      WHEN dialogmote_tidspunkt1 < unntak then dialogmote_tidspunkt2
-      WHEN dialogmote_tidspunkt1 > unntak then dialogmote_tidspunkt1
-    END AS dialogmote3_avholdt_dato,
+      WHEN (dm_2.dialogmote_tidspunkt2 is null) or extract(day from (dm_2.dialogmote_tidspunkt2 - dm_2.tilfelle_startdato)) > 365 then null
+      WHEN dm_2.dialogmote2_avholdt_dato is null then dm_2.dialogmote_tidspunkt1
+      ELSE dialogmote_tidspunkt2
+    END AS dialogmote3_avholdt_dato
+  from dm_2
+  ),
+
+dm_4 as (
+/*
+Setter dialogmote4_avholdt_dato basert på reglene:
+1. Hvis dialogmote_tidspunkt3 = NULL,                             => NULL
+2. Hvis (dialogmote_tidspunkt3 - tilfelle_startdato) > 365 dager, => NULL
+3. Hvis dialogmote2_avholdt_dato = NULL,                          => dialogmote_tidspunkt2
+4. Ellers,                                                        => dialogmote_tidspunkt3
+*/
+    select dm_3.*,
     CASE
-      WHEN (dialogmote_tidspunkt3 is null) or extract(day from (dialogmote_tidspunkt3 - tilfelle_startdato)) > 365 then null
-      WHEN unntak is null then dialogmote_tidspunkt3
-      WHEN dialogmote_tidspunkt2 < unntak then dialogmote_tidspunkt3
-      WHEN dialogmote_tidspunkt2 > unntak then dialogmote_tidspunkt2
-    END AS dialogmote4_avholdt_dato,
+      WHEN (dm_3.dialogmote_tidspunkt3 is null) or extract(day from (dm_3.dialogmote_tidspunkt3 - dm_3.tilfelle_startdato)) > 365 then null
+      WHEN dm_3.dialogmote2_avholdt_dato is null then dm_3.dialogmote_tidspunkt2
+      ELSE dialogmote_tidspunkt3
+    END AS dialogmote4_avholdt_dato
+    from dm_3
+    ),
+
+dm_5 as (
+/*
+Setter dialogmote5_avholdt_dato basert på reglene:
+1. Hvis dialogmote_tidspunkt4 = NULL,                             => NULL
+2. Hvis (dialogmote_tidspunkt4 - tilfelle_startdato) > 365 dager, => NULL
+3. Hvis dialogmote2_avholdt_dato = NULL,                          => dialogmote_tidspunkt3
+4. Ellers,                                                        => dialogmote_tidspunkt4
+*/
+  select dm_4.*,
     CASE
-      WHEN (dialogmote_tidspunkt4 is null) or extract(day from (dialogmote_tidspunkt4 - tilfelle_startdato)) > 365 then null
-      WHEN unntak is null then dialogmote_tidspunkt4
-      WHEN dialogmote_tidspunkt3 < unntak then dialogmote_tidspunkt4
-      WHEN dialogmote_tidspunkt3 > unntak then dialogmote_tidspunkt3
-    END AS dialogmote5_avholdt_dato,
+      WHEN (dm_4.dialogmote_tidspunkt4 is null) or extract(day from (dm_4.dialogmote_tidspunkt4 - dm_4.tilfelle_startdato)) > 365 then null
+      WHEN dm_4.dialogmote2_avholdt_dato is null then dm_4.dialogmote_tidspunkt3
+      else dialogmote_tidspunkt4
+      END AS dialogmote5_avholdt_dato
+      from dm_4
+      ),
+
+dm_6 as (
+/*
+Setter dialogmote6_avholdt_dato basert på reglene:
+1. Hvis dialogmote_tidspunkt5 = NULL,                             => NULL
+2. Hvis (dialogmote_tidspunkt5 - tilfelle_startdato) > 365 dager, => NULL
+3. Hvis dialogmote2_avholdt_dato = NULL,                          => dialogmote_tidspunkt4
+4. Ellers,                                                        => dialogmote_tidspunkt5
+*/
+  select dm_5.*,
     CASE
-      WHEN (dialogmote_tidspunkt5 is null) or extract(day from (dialogmote_tidspunkt5 - tilfelle_startdato)) > 365 then null
-      WHEN unntak is null then dialogmote_tidspunkt5
-      WHEN dialogmote_tidspunkt4 < unntak then dialogmote_tidspunkt5
-      WHEN dialogmote_tidspunkt4 > unntak then dialogmote_tidspunkt4
-    END AS dialogmote6_avholdt_dato,
+      WHEN (dm_5.dialogmote_tidspunkt5 is null) or extract(day from (dm_5.dialogmote_tidspunkt5 - dm_5.tilfelle_startdato)) > 365 then null
+      WHEN dm_5.dialogmote2_avholdt_dato is null then dm_5.dialogmote_tidspunkt4
+      else dialogmote_tidspunkt5
+    END AS dialogmote6_avholdt_dato
+  from dm_5
+  ),
+
+dm_7 as (
+/*
+Setter dialogmote7_avholdt_dato basert på reglene:
+1. Hvis dialogmote_tidspunkt6 = NULL,                             => NULL
+2. Hvis (dialogmote_tidspunkt6 - tilfelle_startdato) > 365 dager, => NULL
+3. Hvis dialogmote2_avholdt_dato = NULL,                          => dialogmote_tidspunkt5
+4. Ellers,                                                        => dialogmote_tidspunkt6
+*/
+  select dm_6.*,
     CASE
-      WHEN (dialogmote_tidspunkt6 is null) or extract(day from (dialogmote_tidspunkt6 - tilfelle_startdato)) > 365 then null
-      WHEN unntak is null then dialogmote_tidspunkt6
-      WHEN dialogmote_tidspunkt5 < unntak then dialogmote_tidspunkt6
-      WHEN dialogmote_tidspunkt5 > unntak then dialogmote_tidspunkt5
+      WHEN (dm_6.dialogmote_tidspunkt6 is null) or extract(day from (dm_6.dialogmote_tidspunkt6 - dm_6.tilfelle_startdato)) > 365 then null
+      WHEN dm_6.dialogmote2_avholdt_dato is null then dm_6.dialogmote_tidspunkt5
+      else dialogmote_tidspunkt6
     END AS dialogmote7_avholdt_dato
-  from hendelser
+  from dm_6
+  ),
+
+dm_2_7 as (
+/*
+Samler alle dialogmote_avholdt_dato fra dm_2 til dm_7
+*/
+  select fk_person1,
+         tilfelle_startdato,
+         dialogmote2_avholdt_dato,
+         dialogmote3_avholdt_dato,
+         dialogmote4_avholdt_dato,
+         dialogmote5_avholdt_dato,
+         dialogmote6_avholdt_dato,
+         dialogmote7_avholdt_dato
+  from dm_7
 )
+
 ,flag_innen_26Uker AS (
   SELECT fk_person1,
          tilfelle_startdato,

--- a/models/dvh_syfo/torg/fak_dialogmote.sql
+++ b/models/dvh_syfo/torg/fak_dialogmote.sql
@@ -26,43 +26,46 @@ WITH hendelser AS (
 ,dm_2_7 as (
 -- copilot er benyttet til å analysere og utvide spørring med flere dialogmøter basert på eksisterende kode
 /*
-Sjekker om unntaksdato er satt for hver dialogmotetidspunkt 1 til 7
-Hvis unntaksdato er NULL               => dialogmote_tidspunkt
-Hvis dialogmøtetidspunkt < unntaksdato => dialogmote_tidspunkt
-Hvis dialogmøtetidspunkt > unntaksdato => null eller tidspunkt for forrige dialogmøte
+Sjekker for hver dialogmotetidspunkt 1 til 7
+1. Hvis dialogmote_tidspunkt = NULL,                             => NULL
+2. Hvis dialogmote_tidspunkt > unntaksdato,                      => NULL
+3. Hvis (dialogmote_tidspunkt - tilfelle_startdato) > 365 dager, => NULL
+4. Hvis unntaksdato = NULL,                                      => dialogmote_tidspunkt
+5. Hvis dialogmøtetidspunkt < unntaksdato,                       => dialogmote_tidspunkt
+6. Hvis dialogmøtetidspunkt > unntaksdato,                       => NULL eller tidspunkt for forrige dialogmøte
 */
   select fk_person1, tilfelle_startdato,
     CASE
-      WHEN (dialogmote_tidspunkt1 > unntak) or (extract(day from (dialogmote_tidspunkt1 - tilfelle_startdato))) > 365 then null
+      WHEN (dialogmote_tidspunkt1 is null) or (dialogmote_tidspunkt1 > unntak) or (extract(day from (dialogmote_tidspunkt1 - tilfelle_startdato))) > 365 then null
       WHEN unntak is null then dialogmote_tidspunkt1
       WHEN dialogmote_tidspunkt1 < unntak then dialogmote_tidspunkt1
     END AS dialogmote2_avholdt_dato,
     CASE
-      WHEN extract(day from (dialogmote_tidspunkt2 - tilfelle_startdato)) > 365 then null
+      WHEN (dialogmote_tidspunkt2 is null) or extract(day from (dialogmote_tidspunkt2 - tilfelle_startdato)) > 365 then null
       WHEN unntak is null then dialogmote_tidspunkt2
       WHEN dialogmote_tidspunkt1 < unntak then dialogmote_tidspunkt2
       WHEN dialogmote_tidspunkt1 > unntak then dialogmote_tidspunkt1
     END AS dialogmote3_avholdt_dato,
     CASE
-      WHEN extract(day from (dialogmote_tidspunkt3 - tilfelle_startdato)) > 365 then null
+      WHEN (dialogmote_tidspunkt3 is null) or extract(day from (dialogmote_tidspunkt3 - tilfelle_startdato)) > 365 then null
       WHEN unntak is null then dialogmote_tidspunkt3
       WHEN dialogmote_tidspunkt2 < unntak then dialogmote_tidspunkt3
       WHEN dialogmote_tidspunkt2 > unntak then dialogmote_tidspunkt2
     END AS dialogmote4_avholdt_dato,
     CASE
-      WHEN extract(day from (dialogmote_tidspunkt4 - tilfelle_startdato)) > 365 then null
+      WHEN (dialogmote_tidspunkt4 is null) or extract(day from (dialogmote_tidspunkt4 - tilfelle_startdato)) > 365 then null
       WHEN unntak is null then dialogmote_tidspunkt4
       WHEN dialogmote_tidspunkt3 < unntak then dialogmote_tidspunkt4
       WHEN dialogmote_tidspunkt3 > unntak then dialogmote_tidspunkt3
     END AS dialogmote5_avholdt_dato,
     CASE
-      WHEN extract(day from (dialogmote_tidspunkt5 - tilfelle_startdato)) > 365 then null
+      WHEN (dialogmote_tidspunkt5 is null) or extract(day from (dialogmote_tidspunkt5 - tilfelle_startdato)) > 365 then null
       WHEN unntak is null then dialogmote_tidspunkt5
       WHEN dialogmote_tidspunkt4 < unntak then dialogmote_tidspunkt5
       WHEN dialogmote_tidspunkt4 > unntak then dialogmote_tidspunkt4
     END AS dialogmote6_avholdt_dato,
     CASE
-      WHEN extract(day from (dialogmote_tidspunkt6 - tilfelle_startdato)) > 365 then null
+      WHEN (dialogmote_tidspunkt6 is null) or extract(day from (dialogmote_tidspunkt6 - tilfelle_startdato)) > 365 then null
       WHEN unntak is null then dialogmote_tidspunkt6
       WHEN dialogmote_tidspunkt5 < unntak then dialogmote_tidspunkt6
       WHEN dialogmote_tidspunkt5 > unntak then dialogmote_tidspunkt5


### PR DESCRIPTION
Fix for null håndtering (sto-3611).

**Beskrivelse av endring:** 
1. Lagt inn ny betingelse for å håndtere null i `dialogmote_tidspunkt` 1-7
2. Oppdatert kommentarer i koden

**Beskrivelse av test:** 
1. Lastet fak_dialogmote på nytt i Rbase
2. Sjekket spørringene under på nytt:
```
Select *
From DVH_SYFO.FAK_DIALOGMOTE
WHERE FK_PERSON1='505644859';

Select *
From DVH_SYFO.FAK_DIALOGMOTE
WHERE DIALOGMOTE6_AVHOLDT_DATO IS NOT NULL AND DIALOGMOTE3_AVHOLDT_DATO IS NULL; 
```