### PR TITLE
sto-2975:endret navn på view og slettet gammelt navn

### DIFF
--- a/models/dvh_syfo/forkammer/modia/fk_modia__aktivitetskrav.sql
+++ b/models/dvh_syfo/forkammer/modia/fk_modia__aktivitetskrav.sql
@@ -8,7 +8,7 @@ WITH aktivitetskrav AS (
   SELECT * FROM {{ ref('fk_modia__aktivitetskrav_raw') }}
 )
 ,dvh_person_ident AS (
-    SELECT * FROM {{ref('felles_dt_person__dvh_person_ident_off_id') }}
+    SELECT * FROM {{ref('felles_dt_person__ident_off_id_til_fk_person1') }}
 )
 , aktivitet_dta AS (
   SELECT

--- a/models/dvh_syfo/kjerne/mk_motebehov__join_fk_person1.sql
+++ b/models/dvh_syfo/kjerne/mk_motebehov__join_fk_person1.sql
@@ -4,7 +4,7 @@ WITH motebehov as (
 )
 
 ,dvh_person_ident AS (
-    SELECT * FROM {{ref('felles_dt_person__dvh_person_ident_off_id') }}
+    SELECT * FROM {{ref('felles_dt_person__ident_off_id_til_fk_person1') }}
 )
 
 , join_fk_person_sm AS (

--- a/models/felles/person/_person_sources.yml
+++ b/models/felles/person/_person_sources.yml
@@ -4,6 +4,5 @@ sources:
   - name: dt_person
     schema: dt_person
     tables:
-    - name: dvh_person_ident_off_id
     - name: dim_person1
     - name: IDENT_OFF_ID_TIL_FK_PERSON1

--- a/models/felles/person/felles_dt_person__dvh_person_ident_off_id.sql
+++ b/models/felles/person/felles_dt_person__dvh_person_ident_off_id.sql
@@ -1,5 +1,0 @@
-WITH source AS (
-  SELECT * FROM {{ source('dt_person', 'dvh_person_ident_off_id') }}
-)
-
-SELECT * FROM source

--- a/tests/syfra/person_ikke_kode67.sql
+++ b/tests/syfra/person_ikke_kode67.sql
@@ -1,7 +1,7 @@
 SELECT teller.fnr
 FROM {{ ref('test__ssb_syfra_teller_kv') }} teller
 LEFT JOIN
-  {{ source('dt_person', 'dvh_person_ident_off_id') }} person_ident ON
+  {{ source('dt_person', 'ident_off_id_til_fk_person1') }} person_ident ON
     teller.fnr = person_ident.off_id
     AND person_ident.gyldig_fra_dato <= teller.p_slutt + 45
     AND person_ident.gyldig_til_dato >= teller.p_start


### PR DESCRIPTION
-vi gjorde search og replace av dt_person og fant 5 steder der det ble brukt gammelt navn på viewet.
-Vi testet at fk_modia__aktivitetskrav kjørte ok i R-basen, men ingen nye rader
-mk_motebehov_join_fk_person1 feilet av andre årsaker så den er ikke lastet ok.
-person_ikke_kode67 er ikke testet fordi den er i testfolder og vi vet ikke helt hva den gjør
-vi slettet models/felles/person/felles_dt_person__dvh_person_ident_off_id.sql da poenget er at den er erstattet med nytt view
-vi fjernet "- name: dvh_person_ident_off_id" fra models/felles/person/_person_sources.yml
