### PR TITLE
Sto 4844 roe sjekk på dato

### DIFF
--- a/models/dvh_syfo/forkammer/modia/fk_modia__dialogmote_patch.sql
+++ b/models/dvh_syfo/forkammer/modia/fk_modia__dialogmote_patch.sql
@@ -3,19 +3,6 @@
 with dialogmote_forkammer as
 (SELECT * FROM {{ref('fk_modia__dialogmote')}})
 
--- Finn dialogmøter som er avholdt av ROE Vestviken
-, dialogmote_roe as (
-  select d.fk_person1,
-         d.hendelse,
-         cast(d.dialogmote_tidspunkt as date) as hendelse_dato,
-         1 as roe_flagg
-      --   case when nav_ident in ('B160279', 'G154329', 'L154047', 'N146924') then 1 else 0 end
-  from dialogmote_forkammer d
-  join dim_syfo_reg_oppf_enhet_ident r on r.nav_ident = d.nav_ident
-  where d.hendelse = 'FERDIGSTILT'
-  and trunc(d.dialogmote_tidspunkt) between r.gyldig_fom_dato and r.gyldig_tom_dato
-)
-
 , dialogmote_patch as (
   select dialogmote_forkammer.*,
   case
@@ -41,13 +28,6 @@ with dialogmote_forkammer as
   from dialogmote_forkammer
 )
 
-dm_med_roe_flagg as (
-  select p.*
-  r.roe_flagg
-  from dialogmote_patch p
-  left outer join dialogmote_roe r on r.fk_person1 = p.fk_person1 and r.hendelse = d.hendelse and r.hendelse_dato = cast(d.dialogmote_tidspunkt as date)
-)
-
 , final AS (
   SELECT
     kilde_uuid,
@@ -62,14 +42,13 @@ dm_med_roe_flagg as (
     arbeidstaker_flagg,
     arbeidsgiver_flagg,
     sykmelder_flagg,
-    roe_flagg,
     kafka_topic,
     kafka_partisjon,
     kafka_offset,
     kafka_mottatt_dato,
     lastet_dato,
     kildesystem
-  FROM dm_med_roe_flagg
+  FROM dialogmote_patch
 )
 
 SELECT * FROM final

--- a/models/dvh_syfo/kjerne/mk_dialogmote__pivotert.sql
+++ b/models/dvh_syfo/kjerne/mk_dialogmote__pivotert.sql
@@ -85,7 +85,6 @@ NB! Må bruke min(dialogmote_tidspunkt) for ikkje å få med for mange rader. Sk
     ,tilfelle_startdato
 ),
 
--- Left outer join mot dialogmote_roe for å få satt region_oppf_enhet_vviken_flagg
 final as (
     SELECT
       pivotert.fk_person1,


### PR DESCRIPTION
Lagt på sjekk på om nav-ident ligg i tabellen dim_syfo_reg_oppf_enhet_ident, og om hendelse skjer i tidsrommet gyldig-fra-til for identen. I så fall blir region_oppf_enhet_vviken_flagg satt til 1 på det aktuelle tilfellet.