### PR TITLE
Sto 5263 unntak historikk

### DIFF
--- a/models/dvh_syfo/forkammer/modia/_modia__models.yml
+++ b/models/dvh_syfo/forkammer/modia/_modia__models.yml
@@ -6,3 +6,9 @@ models:
     columns:
       - name: kilde_uuid
         description: Unik id for hendelsen
+
+  - name: fk_modia__kandidat_unntak
+    description: Kandidatliste endringer, inkludert nav-ident på unntak
+    columns:
+      - name: kilde_uuid
+        description: Unik id for hendelsen

--- a/models/dvh_syfo/forkammer/modia/_modia__sources.yml
+++ b/models/dvh_syfo/forkammer/modia/_modia__sources.yml
@@ -16,3 +16,7 @@ sources:
       description: Møtebehov RAW fra sky
     - name: fk_syfo_person_oversikt_status
       description: Kandidater for dialogmøte med korrekte nav -enheter
+
+    - name: fk_dm_unntak_historikk_fra_2023
+      description:  Tabell som inneheld info om nav-ident kopla til unntak for dialogmøter.
+                    Data vart lasta inn som ein eingongsjobb i februar 2025. Ref STO-5263

--- a/models/dvh_syfo/forkammer/modia/fk_modia__kandidat_unntak.sql
+++ b/models/dvh_syfo/forkammer/modia/fk_modia__kandidat_unntak.sql
@@ -1,5 +1,5 @@
 WITH kandidater AS (
-  SELECT * FROM {{ ref('modia', 'fk_modia__kandidat') }}
+  SELECT * FROM {{ ref('fk_modia__kandidat') }}
 ),
 
 final as (
@@ -8,19 +8,20 @@ final as (
     k.hendelse_tidspunkt,
     k.fk_person1,
     k.kandidat_flagg,
-    k.hendelseunntakarsak,
+    k.hendelse,
+    k.unntakarsak,
     k.tilfelle_startdato,
-    nvl(u.nav_ident, k.nav_ident) as nav_ident,
-    kafka_topic,
-    kafka_partisjon,
-    kafka_offset,
-    kafka_mottatt_dato,
-    lastet_dato,
-    kildesystem
+    nvl(u.created_by, k.nav_ident) as nav_ident,
+    k.kafka_topic,
+    k.kafka_partisjon,
+    k.kafka_offset,
+    k.kafka_mottatt_dato,
+    k.lastet_dato,
+    k.kildesystem
   from kandidater k
-  join {{ source('modia', 'fk_dm_unntak_historikk_fra_2023') }} u
+  left outer join {{ source('modia', 'fk_dm_unntak_historikk_fra_2023') }} u
     on k.fk_person1 = u.fk_person1
     and trunc(k.hendelse_tidspunkt) = u.created_at_dato
-),
+)
 
 select * from final

--- a/models/dvh_syfo/forkammer/modia/fk_modia__kandidat_unntak.sql
+++ b/models/dvh_syfo/forkammer/modia/fk_modia__kandidat_unntak.sql
@@ -1,0 +1,26 @@
+WITH kandidater AS (
+  SELECT * FROM {{ ref('modia', 'fk_modia__kandidat') }}
+),
+
+final as (
+  select
+    k.kilde_uuid,
+    k.hendelse_tidspunkt,
+    k.fk_person1,
+    k.kandidat_flagg,
+    k.hendelseunntakarsak,
+    k.tilfelle_startdato,
+    nvl(u.nav_ident, k.nav_ident) as nav_ident,
+    kafka_topic,
+    kafka_partisjon,
+    kafka_offset,
+    kafka_mottatt_dato,
+    lastet_dato,
+    kildesystem
+  from kandidater k
+  join {{ source('modia', 'fk_dm_unntak_historikk_fra_2023') }} u
+    on k.fk_person1 = u.fk_person1
+    and trunc(k.hendelse_tidspunkt) = u.created_at_dato
+),
+
+select * from final

--- a/models/dvh_syfo/kjerne/mk_dialogmote__union.sql
+++ b/models/dvh_syfo/kjerne/mk_dialogmote__union.sql
@@ -7,7 +7,7 @@
 *********************************************************/
 WITH union_all AS (
   {{ dbt_utils.union_relations(
-    relations=[ref('fk_modia__kandidat'), ref('fk_modia__dialogmote_patch'), ref('mk_dialogmote__omkode_arena_hendelse')],
+    relations=[ref('fk_modia__kandidat_unntak'), ref('fk_modia__dialogmote_patch'), ref('mk_dialogmote__omkode_arena_hendelse')],
     source_column_name=None
   ) }}
 )


### PR DESCRIPTION
Joinar inn nav-identar frå uttekket vi fekk frå Lars med nav-ident på UNNTAK tilbake i tid.
Testa køyringar av dei veiwa som har blitt endra, sjekka at antall rader før og etter er likt.
Prøvde å køyre fak_dialogmote, men der fekk eg 'name is already used by an existing object'.
Brukar ikkje tid på den feilen, for den pleier vi jo ikkje å få i prod.