### PR TITLE
STO-7016 fjerne dt_p.dim_naering og måte og hente primærnæring

### DIFF
--- a/models/syfra/agg_ia_sykefravar/agg_ia_sykefravar__virksomhet_metadata.sql
+++ b/models/syfra/agg_ia_sykefravar/agg_ia_sykefravar__virksomhet_metadata.sql
@@ -53,14 +53,10 @@ sykefravar_statistikk_virksomhet_metadata as (
     arstall,
     kvartal,
     sektor,
-    gruppe3_kode as primar_naring,
+    substr(primar_naring_kode, 1, 2) as primar_naring,
     primar_naring_kode,
     rectype
   from sykefravar_statistikk
-  left join dt_p.dim_naering nar on
-    nar.naering_kode = primar_naring_kode
-    and trunc(siste_dag_i_kvartal) between trunc(gyldig_fra_dato) and trunc(gyldig_til_dato)
-    and naeringsstandard = 'SN2007'
 ),
 
 final as (


### PR DESCRIPTION
### Tester: 

**At resultatet av nytt felt er det samme, her er resultatet 0 rader:**
`select m.*, substr(primar_naring_kode, 1, 2) as kode3 from AGG_IA_SYKEFRAVAR__VIRKSOMHET_METADATA m where primar_naring != substr(primar_naring_kode, 1, 2) ;

**Lagde kopitabell og kjørte ny modell og sjekket at det ikke var diff i radene:**
`
`select * from AGG_IA_SYKEFRAVAR__VIRKSOMHET_METADATA MINUS select * from AGG_IA_SYKEFRAVAR__VIRKSOMHET_METADATA_kopi;
`